### PR TITLE
Render empty array when defined as default value for property

### DIFF
--- a/Parser/PlantUmlEntityParser.php
+++ b/Parser/PlantUmlEntityParser.php
@@ -124,6 +124,10 @@ class PlantUmlEntityParser
             if (is_bool($default)) {
                 $default = ($default) ? 'true' : 'false';
             }
+
+            if (is_array($default)) {
+                $default = '[]';
+            }
         }
 
         $reflection = $classMetadata->getReflectionProperty($fieldName);


### PR DESCRIPTION
I encounter an error while generating the ERM:
```
ErrorException:
Notice: Array to string conversion
```
The problem is here, the empty array:
```php
private $parameters = [];
```

This PR fixes the error
